### PR TITLE
Added the update shell script as suggested in #11

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -114,13 +114,7 @@ $(C_EXE): $(C_OBJ) $(GNL_OBJ)
 # Checks wether to perform an update.
 .phony: update
 update:
-ifeq ($(shell git fetch && git status | head -n 2 | grep behind | wc -l | xargs),1)
-	$(info )
-	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
-	$(info @@@ An update is available. You can install it by typing 'git pull' @@@)
-	$(info @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@)
-	$(info )
-endif
+	- ./update.sh
 
 # Remove all temporary files.
 .phony: clean

--- a/src/update.sh
+++ b/src/update.sh
@@ -1,0 +1,11 @@
+#/bin/sh
+version=v0.1
+git fetch --all
+newVersion=$(git tag | tail -n 1)
+if [ "$version" != "$newVersion" ]; then
+	echo "Update available. Will perform it now..."
+	hash=$(git log -t $version --pretty='%H' -n 1)
+	git reset $hash --hard
+	git pull --force
+fi
+echo "Up to date"


### PR DESCRIPTION
Added the suggested shell script. The script only updates the local copy of the tester if a new release has been published. Of course you can bypass it, but by default, and the user editing only what he is supposed to, it should update the tester properly.